### PR TITLE
Added default preselected modules in offline installation (jsc#SLE-8040)

### DIFF
--- a/package/installation.xml
+++ b/package/installation.xml
@@ -36,6 +36,15 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
         </minimal_role_description>
     </texts>
 
+    <software>
+        <!-- the default preselected modules in offline installation -->
+        <default_modules config:type="list">
+            <default_module>sle-module-basesystem</default_module>
+            <default_module>sle-module-hpc</default_module>
+            <default_module>sle-module-python2</default_module>
+        </default_modules>
+    </software>
+
     <partitioning>
        <expert_partitioner_warning config:type="boolean">false</expert_partitioner_warning>
 

--- a/package/skelcd-control-SLE_HPC.changes
+++ b/package/skelcd-control-SLE_HPC.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 26 13:04:31 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added default preselected modules in offline installation
+  (jsc#SLE-8040)
+- 15.2.2
+
+-------------------------------------------------------------------
 Thu Dec  5 08:21:35 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Run the registration also on the Full medium (jsc#SLE-7214)

--- a/package/skelcd-control-SLE_HPC.spec
+++ b/package/skelcd-control-SLE_HPC.spec
@@ -37,7 +37,7 @@ Provides:       system-installation() = SLE-HPC
 
 Url:            https://github.com/yast/skelcd-control-SLE_HPC
 AutoReqProv:    off
-Version:        15.2.1
+Version:        15.2.2
 Release:        3
 Summary:        SLE_HPC control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Added the default preselected modules in offline installation
- Related to https://jira.suse.com/browse/SLE-8040 and https://jira.suse.com/browse/SLE-11455
- From JIRA: SLE HPC: Basesystem, HPC, Python
- 15.2.2