### PR TITLE
Update the preselected modules on Full medium (bsc#1211278)

### DIFF
--- a/package/installation.xml
+++ b/package/installation.xml
@@ -40,8 +40,11 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
         <!-- the default preselected modules in offline installation -->
         <default_modules config:type="list">
             <default_module>sle-module-basesystem</default_module>
+            <default_module>sle-module-desktop-applications</default_module>
+            <default_module>sle-module-development-tools</default_module>
             <default_module>sle-module-hpc</default_module>
-            <default_module>sle-module-python2</default_module>
+            <default_module>sle-module-server-applications</default_module>
+            <default_module>sle-module-web-scripting</default_module>
         </default_modules>
     </software>
 

--- a/package/skelcd-control-SLE_HPC.changes
+++ b/package/skelcd-control-SLE_HPC.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  1 11:48:19 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- When installing from the Full installation medium preselect the
+  same modules as installation from the Online medium (bsc#1211278)
+- 15.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 15.5.0 (bsc#1198109)

--- a/package/skelcd-control-SLE_HPC.spec
+++ b/package/skelcd-control-SLE_HPC.spec
@@ -37,7 +37,7 @@ Provides:       system-installation() = SLE-HPC
 
 Url:            https://github.com/yast/skelcd-control-SLE_HPC
 AutoReqProv:    off
-Version:        15.5.0
+Version:        15.5.1
 Release:        3
 Summary:        SLE_HPC control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

- The default selection causes dependency issues
- The preselected modules do not match the SCC default modules
- See https://bugzilla.suse.com/show_bug.cgi?id=1211278


## Solution

- Update the list of modules, see [this Bugzilla comment](https://bugzilla.suse.com/show_bug.cgi?id=1211278#c2)

## Testing

- I manually verified that it is the same as the default modules from SCC
